### PR TITLE
Added corecell armv7hf and rpi default architectures

### DIFF
--- a/setup.gmk
+++ b/setup.gmk
@@ -45,6 +45,7 @@ ARCH.linux.default   = x86_64-linux-gnu
 ARCH.linuxV2.default = x86_64-linux-gnu
 ARCH.linuxpico.default = x86_64-linux-gnu
 ARCH.corecell.default  = arm-linux-gnueabihf
+ARCH.corecell.armv7hf  = arm-linux-gnueabihf
 ARCH.corecell.aarch64  = aarch64-linux-gnu
 ARCH.rpi.armv7hf  = arm-linux-gnueabihf
 ARCH.rpi.aarch64  = aarch64-linux-gnu

--- a/setup.gmk
+++ b/setup.gmk
@@ -47,6 +47,7 @@ ARCH.linuxpico.default = x86_64-linux-gnu
 ARCH.corecell.default  = arm-linux-gnueabihf
 ARCH.corecell.armv7hf  = arm-linux-gnueabihf
 ARCH.corecell.aarch64  = aarch64-linux-gnu
+ARCH.rpi.default  = arm-linux-gnueabihf
 ARCH.rpi.armv7hf  = arm-linux-gnueabihf
 ARCH.rpi.aarch64  = aarch64-linux-gnu
 ARCH.kerlink.default = arm-klk-linux-gnueabi


### PR DESCRIPTION
Added corecell armv7hf and rpi default architectures to enable Raspberry Pi 3 type of devices (e.g. balenaFin) to work with RAK2245 or 2287.