### PR TITLE
Changes for sx1301 concentrators

### DIFF
--- a/deps/lgw/v5.0.1-kerlink.patch
+++ b/deps/lgw/v5.0.1-kerlink.patch
@@ -125,7 +125,8 @@ index c01ed1c..0e2b64c 100644
 @@ -54,7 +54,7 @@ Maintainer: Sylvain Miermont
  #define READ_ACCESS     0x00
  #define WRITE_ACCESS    0x80
- #define SPI_SPEED       8000000
+-#define SPI_SPEED       8000000
++#define SPI_SPEED       (getenv("SPI_SPEED")==NULL ? 8000000 : getenv("SPI_SPEED"))
 -#define SPI_DEV_PATH    "/dev/spidev0.0"
 +#define SPI_DEV_PATH    (getenv("LORAGW_SPI")==NULL ? "/dev/spidev0.0" : getenv("LORAGW_SPI"))
  //#define SPI_DEV_PATH    "/dev/spidev32766.0"

--- a/deps/lgw/v5.0.1-linux.patch
+++ b/deps/lgw/v5.0.1-linux.patch
@@ -126,7 +126,7 @@ index c01ed1c..0e2b64c 100644
  #define READ_ACCESS     0x00
  #define WRITE_ACCESS    0x80
 -#define SPI_SPEED       8000000
-+#define SPI_SPEED       2000000
++#define SPI_SPEED       (getenv("SPI_SPEED")==NULL ? 2000000 : getenv("SPI_SPEED"))
 -#define SPI_DEV_PATH    "/dev/spidev0.0"
 +#define SPI_DEV_PATH    (getenv("LORAGW_SPI")==NULL ? "/dev/spidev0.0" : getenv("LORAGW_SPI"))
  //#define SPI_DEV_PATH    "/dev/spidev32766.0"

--- a/deps/lgw/v5.0.1-rpi.patch
+++ b/deps/lgw/v5.0.1-rpi.patch
@@ -126,7 +126,7 @@ index c01ed1c..0e2b64c 100644
  #define READ_ACCESS     0x00
  #define WRITE_ACCESS    0x80
 -#define SPI_SPEED       8000000
-+#define SPI_SPEED       2000000
++#define SPI_SPEED       (getenv("SPI_SPEED")==NULL ? 2000000 : getenv("SPI_SPEED"))
 -#define SPI_DEV_PATH    "/dev/spidev0.0"
 +#define SPI_DEV_PATH    (getenv("LORAGW_SPI")==NULL ? "/dev/spidev0.0" : getenv("LORAGW_SPI"))
  //#define SPI_DEV_PATH    "/dev/spidev32766.0"

--- a/start_sx1301.sh
+++ b/start_sx1301.sh
@@ -18,8 +18,11 @@ echo "Resetting gateway concentrator on GPIO $GW_RESET_GPIO"
 echo $GW_RESET_GPIO > /sys/class/gpio/export
 echo out > /sys/class/gpio/gpio$GW_RESET_GPIO/direction
 echo 0 > /sys/class/gpio/gpio$GW_RESET_GPIO/value
+sleep 1
 echo 1 > /sys/class/gpio/gpio$GW_RESET_GPIO/value
+sleep 1
 echo 0 > /sys/class/gpio/gpio$GW_RESET_GPIO/value
+sleep 1
 echo $GW_RESET_GPIO > /sys/class/gpio/unexport
 
 RADIODEV=/dev/spidev0.0 ../../build-rpi-std/bin/station 


### PR DESCRIPTION
- Introduce a spi_speed device environment variable
- add a delay during the reset sequence for the sx1301