### PR TITLE
Added code to sanitize TC_TRUST variable

### DIFF
--- a/start_common.sh
+++ b/start_common.sh
@@ -22,6 +22,9 @@ fi
 
 echo "Server: $TC_URI"
 
+# Sanitize TC_TRUST
+TC_TRUST=$(echo $TC_TRUST | sed 's/-----BEGIN CERTIFICATE-----/-----BEGIN CERTIFICATE-----\n/' | sed 's/-----END CERTIFICATE-----/\n-----END CERTIFICATE-----/' | sed 's/\n\n/\n/g')
+
 # declare map of hardware pins to GPIO on Raspberry Pi
 declare -a pinToGPIO
 pinToGPIO=( -1 -1 -1 2 -1 3 -1 4 14 -1 15 17 18 27 -1 22 23 -1 24 10 -1 9 25 11 8 -1 7 0 1 5 -1 6 12 13 -1 19 16 26 20 -1 21)


### PR DESCRIPTION
While copying certificates from other locations the `-----BEGIN CERTIFICATE----` and `-----END CERTIFICATE----` might get mixed with the certificate and they have to be in separate lines.